### PR TITLE
Add missing shebang

### DIFF
--- a/project_name/manage.py
+++ b/project_name/manage.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import os
 import sys
 


### PR DESCRIPTION
This file is marked as executable (+x) and it must have a valid shebang.